### PR TITLE
Fixes a TypeError using this example

### DIFF
--- a/news/sitemaps.py
+++ b/news/sitemaps.py
@@ -13,7 +13,7 @@ class NewsSitemap(Sitemap):
     def items(self):
         return NewsItem.objects.filter(
             published=True,
-            news_date__lte=timezone.now,
+            news_date__lte=timezone.now(),
         )
 
     def location(self, item):


### PR DESCRIPTION
`timezone.now` is a function so needs to be called to get this queryset.